### PR TITLE
Fix: additional HTML removed, sound issue fix

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,8 +27,6 @@
                 <div class="cell" id="six"></div>
                 <div class="cell" id="seven"></div>
                 <div class="cell" id="eight"></div>
-                <div class="cell" id="nine"></div>
-                <div class="cell" id="ten"></div>
             </div>
         </div>
         <button>START</button>

--- a/script.js
+++ b/script.js
@@ -51,12 +51,13 @@ const gameOver = () => {
 }
 
 const handleGameClick = e => {
+    audioTurn.currentTime = 0
     audioTurn.play();
     blinkBox(e.target, 0)
     const correctIndex = GAME_PATTERN[USER_CLICK_COUNT]
     USER_CLICK_COUNT++
     if(e.target!==cells[correctIndex]){
-        audioTurn.pause();
+        audioTurn.pause()
         audioGameOver.play()
         alert("Gameover")
     gameOver()
@@ -65,7 +66,7 @@ const handleGameClick = e => {
   if(USER_CLICK_COUNT===LEVEL){
     GAME_PATTERN = []
     USER_CLICK_COUNT = 0
-    setTimeout(runPattern,500)
+    setTimeout(runPattern,300)
   }
 }
 


### PR DESCRIPTION
you added 10 cells instead of 8 which made 2 cells overlap on each other creating an issue that sometimes pattern does not show.
also, before playing the audioturn sound, set its time to 0 so that if the clip is already playing, it starts from 0